### PR TITLE
Fix fromJson method.

### DIFF
--- a/lib/models/jwt_response.dart
+++ b/lib/models/jwt_response.dart
@@ -37,14 +37,18 @@ class WooJWTResponse {
   String userNicename;
   String userDisplayName;
 
-  WooJWTResponse(
-      {this.token, this.userEmail, this.userNicename, this.userDisplayName});
+  WooJWTResponse({
+    this.token,
+    this.userEmail,
+    this.userNicename,
+    this.userDisplayName,
+  });
 
   WooJWTResponse.fromJson(Map<String, dynamic> json) {
-    token = json['token'];
-    userEmail = json['user_email'];
-    userNicename = json['user_nicename'];
-    userDisplayName = json['user_display_name'];
+    token = json['data']['token'];
+    userEmail = json['data']['user_email'];
+    userNicename = json['data']['user_nicename'];
+    userDisplayName = json['data']['user_display_name'];
   }
 
   Map<String, dynamic> toJson() {
@@ -55,5 +59,7 @@ class WooJWTResponse {
     data['user_display_name'] = this.userDisplayName;
     return data;
   }
-  @override toString() => this.toJson().toString();
+
+  @override
+  toString() => this.toJson().toString();
 }


### PR DESCRIPTION
JWT plugins returns data in "data" key.

Example from Postman:

```
{
    "success": true,
    "statusCode": 200,
    "code": "jwt_auth_valid_credential",
    "message": "Credential is valid",
    "data": {
        "token": "token string here",
        "id": 1,
        "email": "info@example.com",
        "nicename": "christian",
        "firstName": "Christian",
        "lastName": "Giupponi",
        "displayName": "christian"
    }
}
```