### PR TITLE
Fix MetaData.fromJson in order.dart for non String value

### DIFF
--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -498,7 +498,7 @@ class MetaData {
   MetaData.fromJson(Map<String, dynamic> json) {
     id = json['id'];
     key = json['key'];
-    value = json['value'];
+    value = json['value'].toString();
   }
 
   Map<String, dynamic> toJson() {


### PR DESCRIPTION
Hello,
I've experienced an error with MetaData.fromJson in order.dart file. 
In order creation, I received a response like this: 

`meta_data: [{id: 18, key: community-events-location, value: {ip: xx.xx.xx.xx}}, {id: 23, key: wc_last_active, value: 1603756800},{..}]`

where there is an object instead of a string for the "value" tag: `value: {ip: xx.xx.xx.xx}`.

The named constructor must change from: 

```
MetaData.fromJson(Map<String, dynamic> json) {
    id = json['id'];
    key = json['key'];
    value = json['value'];
  }
```
to: 
```
MetaData.fromJson(Map<String, dynamic> json) {
    id = json['id'];
    key = json['key'];
    value = json['value'].toString();
  }
```